### PR TITLE
exclude --no-reuse-hashes from pip-compile headers

### DIFF
--- a/piptools/utils.py
+++ b/piptools/utils.py
@@ -24,6 +24,7 @@ COMPILE_EXCLUDE_OPTIONS = {
     "--upgrade-package",
     "--verbose",
     "--cache-dir",
+    "--no-reuse-hashes",
 }
 
 


### PR DESCRIPTION
<!--- Describe the changes here. --->

**Changelog-friendly one-liner**: <!-- One-liner description here -->

##### Contributor checklist

- [ ] Provided the tests for the changes.
- [ ] Gave a clear one-line description in the PR (that the maintainers can add to CHANGELOG.md on release).
- [ ] Assign the PR to an existing or new milestone for the target version (following [Semantic Versioning](https://blog.versioneye.com/2014/01/16/semantic-versioning/)).
